### PR TITLE
Fix landscape mode without using advanced modifiers or adaptive layouts

### DIFF
--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -28,7 +28,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -94,6 +94,7 @@ fun LemonadeApp() {
         Surface(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(innerPadding)
                 .background(MaterialTheme.colorScheme.tertiaryContainer),
             color = MaterialTheme.colorScheme.background
         ) {
@@ -173,7 +174,8 @@ fun LemonTextAndImage(
                     painter = painterResource(drawableResourceId),
                     contentDescription = stringResource(contentDescriptionResourceId),
                     modifier = Modifier
-                        .wrapContentSize()
+                        .width(dimensionResource(R.dimen.button_image_width))
+                        .height(dimensionResource(R.dimen.button_image_height))
                         .padding(dimensionResource(R.dimen.button_interior_padding))
                 )
             }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,5 +19,7 @@
     <dimen name="button_corner_radius">40dp</dimen>
     <dimen name="button_interior_padding">24dp</dimen>
     <dimen name="padding_vertical">32dp</dimen>
+    <dimen name="button_image_width">128dp</dimen>
+    <dimen name="button_image_height">160dp</dimen>
 
 </resources>


### PR DESCRIPTION
wrapContentSize() effectively hardcodes the height at 200dp to match the vector. The issue is that the app's other content takes up half the screen. As any Android device, ancient or modern, will be at least in the 1x screen density category, and nearly all will have a HVGA display or greater, hardcoding a height of 160dp and adjusting the width to maintain the 0.8 aspect ratio should allow the app to run properly in landscape mode while maintaining a large enough size in portrait.

Other approaches considered:

* making the entire layout vertically scrollable
* constraining the button and text column height, and giving the button a weight along with aspect ratio modifier
* using widthIn and maxWidth modifiers with a range
* Fixing the button size and resizing the image to fill the size
* vertical padding and spacers
* horizontal spacers only present in landscape mode (adaptive layouts and window size class not taught yet)
* combination of both vertical and horizontal spacers to enforce a maximum padding and minimum size

In addition, this PR also makes use of the inner padding provided by the scaffold so that the layout is properly centered in the remaining space *below* the top bar.

![Screenshot_20230517_150742](https://github.com/google-developer-training/basic-android-kotlin-compose-training-lemonade/assets/92757524/4b68f0dd-e24f-4529-9aad-67195d96a0ec)

![Screenshot_20230517_150722](https://github.com/google-developer-training/basic-android-kotlin-compose-training-lemonade/assets/92757524/00978831-dca7-4645-8b0b-26c01acebaf4)
