### PR TITLE
E2E and removing scaffold innerpaddig

### DIFF
--- a/app/src/main/java/com/example/lemonade/MainActivity.kt
+++ b/app/src/main/java/com/example/lemonade/MainActivity.kt
@@ -90,11 +90,11 @@ fun LemonadeApp() {
                 )
             )
         }
-    ) { innerPadding ->
+    ) {  innerPadding ->
         Surface(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
+//                .padding(innerPadding)
                 .background(MaterialTheme.colorScheme.tertiaryContainer),
             color = MaterialTheme.colorScheme.background
         ) {
@@ -107,7 +107,8 @@ fun LemonadeApp() {
                         onImageClick = {
                             currentStep = 2
                             squeezeCount = (2..4).random()
-                        }
+                        },
+                        modifier = Modifier.padding(innerPadding)
                     )
                 }
                 2 -> {
@@ -120,7 +121,8 @@ fun LemonadeApp() {
                             if (squeezeCount == 0) {
                                 currentStep = 3
                             }
-                        }
+                        },
+                        modifier = Modifier.padding(innerPadding)
                     )
                 }
 
@@ -131,7 +133,8 @@ fun LemonadeApp() {
                         contentDescriptionResourceId = R.string.lemonade_content_description,
                         onImageClick = {
                             currentStep = 4
-                        }
+                        },
+                        modifier = Modifier.padding(innerPadding)
                     )
                 }
                 4 -> {
@@ -141,7 +144,8 @@ fun LemonadeApp() {
                         contentDescriptionResourceId = R.string.empty_glass_content_description,
                         onImageClick = {
                             currentStep = 1
-                        }
+                        },
+                        modifier = Modifier.padding(innerPadding)
                     )
                 }
             }

--- a/app/src/main/java/com/example/lemonade/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/lemonade/ui/theme/Theme.kt
@@ -18,6 +18,7 @@ package com.example.lemonade.ui.theme
 
 import android.app.Activity
 import android.os.Build
+import android.view.View
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -26,6 +27,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -114,9 +116,7 @@ fun AppTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            setUpEdgeToEdge(view, darkTheme)
         }
     }
 
@@ -125,4 +125,24 @@ fun AppTheme(
         typography = Typography,
         content = content
     )
+}
+
+/**
+ * Sets up edge-to-edge for the window of this [view]. The system icon colors are set to either
+ * light or dark depending on whether the [darkTheme] is enabled or not.
+ */
+private fun setUpEdgeToEdge(view: View, darkTheme: Boolean) {
+    val window = (view.context as Activity).window
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    window.statusBarColor = Color.Transparent.toArgb()
+    val navigationBarColor = when {
+//        Build.VERSION.SDK_INT >= 29 -> Color.Transparent.toArgb()
+        Build.VERSION.SDK_INT >= 26 -> Color(0xFF, 0xFF, 0xFF, 0x63).toArgb()
+        // Min sdk version for this app is 24, this block is for SDK versions 24 and 25
+        else -> Color(0x00,0x00, 0x00, 0x50).toArgb()
+    }
+    window.navigationBarColor = navigationBarColor
+    val controller = WindowCompat.getInsetsController(window, view)
+    controller.isAppearanceLightStatusBars = !darkTheme
+    controller.isAppearanceLightNavigationBars = !darkTheme
 }


### PR DESCRIPTION
Issues that we are trying to address in this PR:

- Content is not being drawn behind the system bars
- Bottom bar is opaque on SDK version 30.

-----
To resolve _Content is not being drawn behind the bottom system bars_, we removed the surface padding and setting it to child elements. But this may not be ideal since child elements may need custom padding. 

**Q1) Is it ideal to not use surface padding and suppress the lint warning 'UnusedMaterial3ScaffoldPaddingParameter'?**

-----
To resolve _Bottom bar is opaque on SDK version 30_ we changed the `window.navigationBarColor` to `Color(0xFF, 0xFF, 0xFF, 0x63).toArgb()` instead of `Color.Transparent.toArgb()`. 

**Q2) Why is `Color.Transparent.toArgb()` not working for SDK version `29` and higher?**

```
    val navigationBarColor = when {
//        Build.VERSION.SDK_INT >= 29 -> Color.Transparent.toArgb()
        Build.VERSION.SDK_INT >= 26 -> Color(0xFF, 0xFF, 0xFF, 0x63).toArgb()
        // Min sdk version for this app is 24, this block is for SDK versions 24 and 25
        else -> Color(0x00,0x00, 0x00, 0x50).toArgb()
    }
    window.navigationBarColor = navigationBarColor
```
------

| Before | After |
|--------|--------|
| <img width="740" alt="image" src="https://github.com/google-developer-training/basic-android-kotlin-compose-training-lemonade/assets/24260141/2c353b7d-062c-4adb-8e7a-f46938c6b091"> | <img width="718" alt="image" src="https://github.com/google-developer-training/basic-android-kotlin-compose-training-lemonade/assets/24260141/cfdc4bc3-98d1-40d4-b1e3-2f9a379329b0"> |

**Q3) What the reason for setting the alpha to 0x63 vs 0x50?**

-------

**Q4) Could we have translucent white or black bottom navigation/ system bar depending on the app theme or this is SDK specific?**

------